### PR TITLE
Add extension (.bat/.sh) if corresponding file exists.

### DIFF
--- a/src/main/groovy/com/github/jlouns/gradle/cpe/tasks/CrossPlatformExec.groovy
+++ b/src/main/groovy/com/github/jlouns/gradle/cpe/tasks/CrossPlatformExec.groovy
@@ -3,6 +3,7 @@ package com.github.jlouns.gradle.cpe.tasks
 import org.gradle.api.tasks.AbstractExecTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
+import java.io.File
 
 /**
  * Created on 1/26/15
@@ -20,14 +21,44 @@ class CrossPlatformExec extends AbstractExecTask {
 	@Override
 	@TaskAction
 	protected void exec() {
+		List<String> commandLine = this.getCommandLine();
+		commandLine.set(0, this.findScript(commandLine.get(0)));
+		
 		if(windows) {
-			List<String> commandLine = this.getCommandLine();
 			commandLine.add(0, '/c');
 			commandLine.add(0, 'cmd');
-
-			this.setCommandLine(commandLine);
 		}
+
+		this.setCommandLine(commandLine);
 		super.exec();
+	}
+
+	private String findScript(String script) {
+		def scriptFile = new File(script)
+		if(scriptFile.isFile()) {
+			return script;
+		}
+		
+		if(windows) {
+			def batScript = new File(script + ".bat");
+			if(batScript.isFile()) {
+				return batScript;
+			}
+
+			def cmdScript = new File(script + ".cmd");
+			if(cmdScript.isFile()) {
+				return cmdScript;
+			}
+		}
+		else {
+			def shScript = new File(script + ".sh")
+			if(shScript.isFile()) {
+				return shScript;
+			}
+		}
+
+
+		return script;
 	}
 
 }


### PR DESCRIPTION
In some cases (ex.: C++ boost libraries) there are two separate scripts for windows and linux:
- bootstrap.bat
- bootstrap.sh

Eventhough you can run .bat file as `cmd /k bootstrap` on windows you can't run shell script without typing .sh extension.
