### PR TITLE
Fix the dependency classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ buildscript {
 		}
 	}
 	dependencies {
-		classpath 'com.github.jlouns:gradle-cross-platform-exec:0.4.1'
+		classpath 'gradle.plugin.com.github.jlouns:gradle-cross-platform-exec-plugin:0.4.1'
 	}
 }
 


### PR DESCRIPTION
The classpath specified in README didn’t work for me (failing with `Could not find com.github.jlouns:gradle-cross-platform-exec:0.4.1`). Replacing it with the classpath [from the Gradle plugin repo](https://plugins.gradle.org/plugin/com.github.jlouns.cpe) helped.
